### PR TITLE
fix for token scenario issue

### DIFF
--- a/src/video.js/index.js
+++ b/src/video.js/index.js
@@ -89,7 +89,7 @@ class VideojsPlayer extends BasePlayer {
       authentication = true
     }
 
-    if (authentication) {
+    if (authentication || options.uri.includes("keydeliver")) {
       options.headers = options.headers || {}
       options.headers.Authorization = 'Bearer=' + this.getInputToken()
     }


### PR DESCRIPTION
added options.uri.includes("keydeliver") in line 92 to cover the scenario where only TOKEN is selected and JWT token is provided, but no other DRM is selected. it seesm that this case was not covered and hence it did not work, AES encryptet streams did not work as bearer token was never applied in that case.